### PR TITLE
Add AccessControl Layer for WordPress

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"require": {
 		"php": "^7.4|^8.0",
 		"ext-json": "*",
-		"datakit/sdk": "dev-main"
+		"datakit/sdk": "dev-feature/acl"
 	},
 	"config": {
 		"optimize-autoloader": true,
@@ -50,7 +50,8 @@
 		"wp-coding-standards/wpcs": "^3.1",
 		"squizlabs/php_codesniffer": "^3.10",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"overtrue/phplint": "^3.4"
+		"overtrue/phplint": "^3.4",
+		"roots/wordpress-no-content": "^6.6"
 	},
 	"scripts": {
 		"build": [

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"require": {
 		"php": "^7.4|^8.0",
 		"ext-json": "*",
-		"datakit/sdk": "dev-feature/acl"
+		"datakit/sdk": "dev-main"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -9,10 +9,16 @@
         {
             "name": "datakit/sdk",
             "version": "dev-feature/acl",
-            "dist": {
-                "type": "path",
-                "url": "../DataKit-sdk",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/UseDataKit/SDK.git",
                 "reference": "7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/UseDataKit/SDK/zipball/7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc",
+                "reference": "7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc",
+                "shasum": ""
             },
             "require": {
                 "ext-json": "*",
@@ -79,9 +85,11 @@
                 }
             ],
             "description": "Easily create your own DataViews components with just PHP.",
-            "transport-options": {
-                "relative": true
-            }
+            "support": {
+                "source": "https://github.com/UseDataKit/SDK/tree/feature/acl",
+                "issues": "https://github.com/UseDataKit/SDK/issues"
+            },
+            "time": "2024-09-16T09:02:28+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8528064048016873b62d9c97f6209903",
+    "content-hash": "aa356fe82fb7173c6dada711618e231f",
     "packages": [
         {
             "name": "datakit/sdk",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/UseDataKit/SDK.git",
-                "reference": "27fea2c3cbce26370bf842a62a4ae7b26b15df49"
-            },
+            "version": "dev-feature/acl",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/UseDataKit/SDK/zipball/27fea2c3cbce26370bf842a62a4ae7b26b15df49",
-                "reference": "27fea2c3cbce26370bf842a62a4ae7b26b15df49",
-                "shasum": ""
+                "type": "path",
+                "url": "../DataKit-sdk",
+                "reference": "7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc"
             },
             "require": {
                 "ext-json": "*",
@@ -35,7 +29,6 @@
             "suggest": {
                 "ext-pdo": "PDO is required to use the SQLite cache provider"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -86,11 +79,9 @@
                 }
             ],
             "description": "Easily create your own DataViews components with just PHP.",
-            "support": {
-                "source": "https://github.com/UseDataKit/SDK/tree/main",
-                "issues": "https://github.com/UseDataKit/SDK/issues"
-            },
-            "time": "2024-09-11T11:33:34+00:00"
+            "transport-options": {
+                "relative": true
+            }
         }
     ],
     "packages-dev": [
@@ -1498,6 +1489,76 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
             "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "roots/wordpress-no-content",
+            "version": "6.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress.git",
+                "reference": "6.6.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/release/wordpress-6.6.2-no-content.zip",
+                "shasum": "b496b8a9bb3c6d20a781344cbe3e189f7fd83871"
+            },
+            "require": {
+                "php": ">= 7.2.24"
+            },
+            "provide": {
+                "wordpress/core-implementation": "6.6.2"
+            },
+            "suggest": {
+                "ext-curl": "Performs remote request operations.",
+                "ext-dom": "Used to validate Text Widget content and to automatically configuring IIS7+.",
+                "ext-exif": "Works with metadata stored in images.",
+                "ext-fileinfo": "Used to detect mimetype of file uploads.",
+                "ext-hash": "Used for hashing, including passwords and update packages.",
+                "ext-imagick": "Provides better image quality for media uploads.",
+                "ext-json": "Used for communications with other servers.",
+                "ext-libsodium": "Validates Signatures and provides securely random bytes.",
+                "ext-mbstring": "Used to properly handle UTF8 text.",
+                "ext-mysqli": "Connects to MySQL for database interactions.",
+                "ext-openssl": "Permits SSL-based connections to other hosts.",
+                "ext-pcre": "Increases performance of pattern matching in code searches.",
+                "ext-xml": "Used for XML parsing, such as from a third-party site.",
+                "ext-zip": "Used for decompressing Plugins, Themes, and WordPress update packages."
+            },
+            "type": "wordpress-core",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
+            "homepage": "https://wordpress.org/",
+            "keywords": [
+                "blog",
+                "cms",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://developer.wordpress.org/",
+                "forum": "https://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "https://core.trac.wordpress.org/",
+                "rss": "https://wordpress.org/news/feed/",
+                "source": "https://core.trac.wordpress.org/browser",
+                "wiki": "https://codex.wordpress.org/"
+            },
+            "funding": [
+                {
+                    "url": "https://wordpressfoundation.org/donate/",
+                    "type": "other"
+                }
+            ],
+            "time": "2024-09-10T15:25:31+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa356fe82fb7173c6dada711618e231f",
+    "content-hash": "c2b3105098b6e486ef25a00d3cb5cf75",
     "packages": [
         {
             "name": "datakit/sdk",
-            "version": "dev-feature/acl",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UseDataKit/SDK.git",
-                "reference": "7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc"
+                "reference": "dc89bc13b1e6a54377709f8397f3b9b1926123cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UseDataKit/SDK/zipball/7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc",
-                "reference": "7e64e725bfdaa31603f29dbe3c1edd3bb1f77abc",
+                "url": "https://api.github.com/repos/UseDataKit/SDK/zipball/dc89bc13b1e6a54377709f8397f3b9b1926123cb",
+                "reference": "dc89bc13b1e6a54377709f8397f3b9b1926123cb",
                 "shasum": ""
             },
             "require": {
@@ -35,6 +35,7 @@
             "suggest": {
                 "ext-pdo": "PDO is required to use the SQLite cache provider"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -86,10 +87,10 @@
             ],
             "description": "Easily create your own DataViews components with just PHP.",
             "support": {
-                "source": "https://github.com/UseDataKit/SDK/tree/feature/acl",
+                "source": "https://github.com/UseDataKit/SDK/tree/main",
                 "issues": "https://github.com/UseDataKit/SDK/issues"
             },
-            "time": "2024-09-16T09:02:28+00:00"
+            "time": "2024-09-16T09:56:21+00:00"
         }
     ],
     "packages-dev": [

--- a/src/AccessControl/WordPressAccessController.php
+++ b/src/AccessControl/WordPressAccessController.php
@@ -80,6 +80,6 @@ final class WordPressAccessController implements AccessController {
 		 * @param Capability $capability Whether the user can.
 		 * @param ?WP_User   $user       The WP_User.
 		 */
-		return (bool) apply_filters( 'datakit/acl/can', $can, $capability, $this->user );
+		return (bool) apply_filters( 'datakit/access-control/can', $can, $capability, $this->user );
 	}
 }

--- a/src/AccessControl/WordPressAccessController.php
+++ b/src/AccessControl/WordPressAccessController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DataKit\Plugin\AccessControl;
+
+use DataKit\DataViews\AccessControl\AccessController;
+use DataKit\DataViews\AccessControl\Capability\Capability;
+use DataKit\DataViews\AccessControl\ReadOnlyAccessController;
+use WP_User;
+
+/**
+ * Access Controller backed by a {@see WP_User}.
+ *
+ * @since $ver$
+ */
+final class WordPressAccessController implements AccessController {
+	/**
+	 * The user to test against.
+	 *
+	 * @since $ver$
+	 *
+	 * @var WP_User|null
+	 */
+	private ?WP_User $user;
+
+	/**
+	 * The previous access controller.
+	 *
+	 * @since $ver$
+	 *
+	 * @var AccessController
+	 */
+	private AccessController $previous;
+
+	/**
+	 * Creates the Access Controller.
+	 *
+	 * @since $ver$
+	 *
+	 * @param WP_User|null $user The user to test against.
+	 */
+	public function __construct( ?WP_User $user ) {
+		$this->user     = $user;
+		$this->previous = new ReadOnlyAccessController();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since $ver$
+	 */
+	public function can( Capability $capability ): bool {
+		$can = $this->previous->can( $capability );
+
+		if ( $this->user && $this->user->exists() ) {
+			$can = $this->user->has_cap( 'administrator' );
+		}
+
+		return $this->filter_result( $can, $capability );
+	}
+
+	/**
+	 * Applies filter on the result.
+	 *
+	 * @since $ver$
+	 *
+	 * @param bool       $can        The result to return.
+	 * @param Capability $capability The capability.
+	 *
+	 * @return bool The filtered result.
+	 */
+	private function filter_result( bool $can, Capability $capability ): bool {
+		/**
+		 * Modifies the capability check.
+		 *
+		 * @filter `datakit/acl/can`
+		 *
+		 * @since  $ver$
+		 *
+		 * @param bool       $can        Whether the user can.
+		 * @param Capability $capability Whether the user can.
+		 * @param ?WP_User   $user       The WP_User.
+		 */
+		return (bool) apply_filters( 'datakit/acl/can', $can, $capability, $this->user );
+	}
+}

--- a/src/AccessControl/WordPressAccessController.php
+++ b/src/AccessControl/WordPressAccessController.php
@@ -72,7 +72,7 @@ final class WordPressAccessController implements AccessController {
 		/**
 		 * Modifies the capability check.
 		 *
-		 * @filter `datakit/acl/can`
+		 * @filter `datakit/access-control/can`
 		 *
 		 * @since  $ver$
 		 *

--- a/src/Rest/Router.php
+++ b/src/Rest/Router.php
@@ -2,6 +2,7 @@
 
 namespace DataKit\Plugin\Rest;
 
+use DataKit\DataViews\AccessControl\AccessControlManager;
 use DataKit\DataViews\Data\MutableDataSource;
 use DataKit\DataViews\DataView\DataViewRepository;
 use DataKit\DataViews\Translation\Translatable;
@@ -69,10 +70,13 @@ final class Router {
 	private function __construct( DataViewRepository $data_view_repository ) {
 		$this->data_view_repository = $data_view_repository;
 		$this->translator           = new WordPressTranslator();
-		$this->view_controller      = new ViewController( $data_view_repository, $this->translator );
+		$this->view_controller      = new ViewController(
+			$data_view_repository,
+			AccessControlManager::current(),
+			$this->translator,
+		);
 
-		// @phpstan-ignore return.missing
-		add_filter( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
 	}
 
 	/**

--- a/tests/AccessControl/WordPressAccessControllerTest.php
+++ b/tests/AccessControl/WordPressAccessControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DataKit\Plugin\Tests\AccessControl;
+
+use DataKit\DataViews\AccessControl\Capability\DeleteDataView;
+use DataKit\DataViews\AccessControl\Capability\EditDataView;
+use DataKit\DataViews\AccessControl\Capability\ViewDataView;
+use DataKit\DataViews\Data\ArrayDataSource;
+use DataKit\DataViews\DataView\DataView;
+use DataKit\Plugin\AccessControl\WordPressAccessController;
+use PHPUnit\Framework\TestCase;
+use WP_User;
+
+/**
+ * Unit tests for {@see WordPressAccessController}
+ *
+ * @since $ver$
+ */
+final class WordPressAccessControllerTest extends TestCase {
+	/**
+	 * Test case for {@see WordPressAccessController::can()}.
+	 *
+	 * @since $ver$
+	 */
+	public function test_can(): void {
+		$dataview = DataView::table( 'test', new ArrayDataSource( 'test', [] ), [] );
+		$user     = new WP_User( (object) [ 'ID' => 1 ], 'admin' );
+		$user->add_cap( 'administrator' );
+
+		$guest = new WordPressAccessController( null );
+		$admin = new WordPressAccessController( $user );
+
+		self::assertTrue( $guest->can( new ViewDataView( $dataview ) ) );
+		self::assertFalse( $guest->can( new EditDataView( $dataview ) ) );
+		self::assertFalse( $guest->can( new DeleteDataView( $dataview ) ) );
+
+		self::assertTrue( $admin->can( new EditDataView( $dataview ) ) );
+		self::assertTrue( $admin->can( new DeleteDataView( $dataview ) ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,22 +1,10 @@
 <?php
 
+define( 'WP_SETUP_CONFIG', true );
+define( 'WP_INSTALLING', true );
+define( 'ABSPATH', dirname( __DIR__ ) . '/vendor/roots/wordpress-no-content/' );
+
 require dirname( __DIR__ ) . '/vendor/autoload.php';
+require dirname( __DIR__ ) . '/vendor/roots/wordpress-no-content/wp-settings.php';
 
-// Polyfill for unit tests.
-if ( ! function_exists( 'apply_filters' ) ) {
-	function apply_filters( ...$args ) {
-		return $args[1];
-	}
-}
-
-if ( ! function_exists( '_x' ) ) {
-	function _x( ...$args ) {
-		return $args[0];
-	}
-}
-
-if ( ! function_exists( '__' ) ) {
-	function __( ...$args ) {
-		return $args[0];
-	}
-}
+$wpdb = new wpdb( '', '', '', '' );


### PR DESCRIPTION
This PR is in addition to https://github.com/UseDataKit/SDK/pull/40 and tries to address #11.

It adds a `WordPressAccessController` which currently checks if the users is a admin. If they are, they have all the power; otherwise it falls back to the default `ReadOnlyAccessController` behaviour. 

So this PR might need some (future) work, but it is already very customisable through the `datakit/acl/can` filter. This filter returns the current accessibility (true or false), in addition to the `Capability`( which contains the context to make decisions) and the current `WP_User`. 

The `ViewController` and the short code now both check if the current user can see the dataview, and act accordingly. 

@zackkatz I'm hoping you can fill in the blanks for me as it comes to user roles, or if this might be enough for a first iteration. We can change default behaviour later on; while maintaining the hooks for people to overwrite the logic.

