### PR TITLE
Fix non administrator losing capabilities

### DIFF
--- a/src/AccessControl/WordPressAccessController.php
+++ b/src/AccessControl/WordPressAccessController.php
@@ -51,7 +51,7 @@ final class WordPressAccessController implements AccessController {
 	public function can( Capability $capability ): bool {
 		$can = $this->previous->can( $capability );
 
-		if ( $this->user && $this->user->exists() ) {
+		if ( !$can && $this->user && $this->user->exists() ) {
 			$can = $this->user->has_cap( 'administrator' );
 		}
 

--- a/src/AccessControl/WordPressAccessController.php
+++ b/src/AccessControl/WordPressAccessController.php
@@ -51,7 +51,7 @@ final class WordPressAccessController implements AccessController {
 	public function can( Capability $capability ): bool {
 		$can = $this->previous->can( $capability );
 
-		if ( !$can && $this->user && $this->user->exists() ) {
+		if ( ! $can && $this->user && $this->user->exists() ) {
 			$can = $this->user->has_cap( 'administrator' );
 		}
 

--- a/tests/AccessControl/WordPressAccessControllerTest.php
+++ b/tests/AccessControl/WordPressAccessControllerTest.php
@@ -36,11 +36,11 @@ final class WordPressAccessControllerTest extends TestCase {
 		self::assertFalse( $guest_controller->can( new EditDataView( $dataview ) ) );
 		self::assertFalse( $guest_controller->can( new DeleteDataView( $dataview ) ) );
 
-        self::assertTrue( $user_controller->can( new ViewDataView( $dataview ) ) );
-        self::assertFalse( $user_controller->can( new EditDataView( $dataview ) ) );
-        self::assertFalse( $user_controller->can( new DeleteDataView( $dataview ) ) );
+		self::assertTrue( $user_controller->can( new ViewDataView( $dataview ) ) );
+		self::assertFalse( $user_controller->can( new EditDataView( $dataview ) ) );
+		self::assertFalse( $user_controller->can( new DeleteDataView( $dataview ) ) );
 
-        self::assertTrue( $admin_controller->can( new ViewDataView( $dataview ) ) );
+		self::assertTrue( $admin_controller->can( new ViewDataView( $dataview ) ) );
 		self::assertTrue( $admin_controller->can( new EditDataView( $dataview ) ) );
 		self::assertTrue( $admin_controller->can( new DeleteDataView( $dataview ) ) );
 	}

--- a/tests/AccessControl/WordPressAccessControllerTest.php
+++ b/tests/AccessControl/WordPressAccessControllerTest.php
@@ -24,17 +24,24 @@ final class WordPressAccessControllerTest extends TestCase {
 	 */
 	public function test_can(): void {
 		$dataview = DataView::table( 'test', new ArrayDataSource( 'test', [] ), [] );
-		$user     = new WP_User( (object) [ 'ID' => 1 ], 'admin' );
-		$user->add_cap( 'administrator' );
+		$admin     = new WP_User( (object) [ 'ID' => 1 ], 'admin' );
+		$user      = new WP_User( (object) [ 'ID' => 2 ], 'user' );
+		$admin->add_cap( 'administrator' );
 
-		$guest = new WordPressAccessController( null );
-		$admin = new WordPressAccessController( $user );
+		$guest_controller = new WordPressAccessController( null );
+		$admin_controller = new WordPressAccessController( $admin );
+		$user_controller  = new WordPressAccessController( $user );
 
-		self::assertTrue( $guest->can( new ViewDataView( $dataview ) ) );
-		self::assertFalse( $guest->can( new EditDataView( $dataview ) ) );
-		self::assertFalse( $guest->can( new DeleteDataView( $dataview ) ) );
+		self::assertTrue( $guest_controller->can( new ViewDataView( $dataview ) ) );
+		self::assertFalse( $guest_controller->can( new EditDataView( $dataview ) ) );
+		self::assertFalse( $guest_controller->can( new DeleteDataView( $dataview ) ) );
 
-		self::assertTrue( $admin->can( new EditDataView( $dataview ) ) );
-		self::assertTrue( $admin->can( new DeleteDataView( $dataview ) ) );
+        self::assertTrue( $user_controller->can( new ViewDataView( $dataview ) ) );
+        self::assertFalse( $user_controller->can( new EditDataView( $dataview ) ) );
+        self::assertFalse( $user_controller->can( new DeleteDataView( $dataview ) ) );
+
+        self::assertTrue( $admin_controller->can( new ViewDataView( $dataview ) ) );
+		self::assertTrue( $admin_controller->can( new EditDataView( $dataview ) ) );
+		self::assertTrue( $admin_controller->can( new DeleteDataView( $dataview ) ) );
 	}
 }


### PR DESCRIPTION
If a user is logged in, but isn't an administrator; the `$can` param will always be `false`; stripping any capabilities they might have. This PR fixes that.